### PR TITLE
fix(ordinances): '(구)' 접두 발령기관을 옛 명칭으로 해석

### DIFF
--- a/ordinances/jurisdictions.py
+++ b/ordinances/jurisdictions.py
@@ -43,6 +43,10 @@ class UnknownJurisdiction(ValueError):
 
 def _normalize(raw: str) -> str:
     text = unicodedata.normalize("NFC", raw or "")
+    # law.go.kr marks pre-reorganisation issuers as "(구)…" (e.g. "(구)전라남도"
+    # after the 전남·광주 merger). Those ordinances belong to the old entity, so
+    # drop the marker and resolve against its still-registered name.
+    text = re.sub(r"^\s*\(\s*구\s*\)\s*", "", text)
     for old, new in HANJA_ALIAS.items():
         text = text.replace(old, new)
     return re.sub(r"\s+", " ", text).strip()

--- a/tests/test_ordinances/test_converter.py
+++ b/tests/test_ordinances/test_converter.py
@@ -268,14 +268,32 @@ def test_compute_path_replaces_slashes():
 
 
 def test_xml_to_markdown_preserves_unknown_jurisdiction_under_fallback_path():
+    """A genuinely unrecognised issuer must land in `_미상/` rather than fail."""
+    xml = SAMPLE_XML.replace("서울특별시</지자체기관명>", "없는광역시 어딘가구</지자체기관명>")
+
+    path, markdown = converter.xml_to_markdown(xml)
+
+    assert path == "_미상/없는광역시 어딘가구/조례/서울특별시 테스트 조례/본문.md"
+    assert _frontmatter(markdown)["지자체구분"] == {
+        "광역": "_미상",
+        "기초": "없는광역시 어딘가구",
+    }
+
+
+def test_xml_to_markdown_resolves_former_jurisdiction_marker():
+    """`(구)…` marks a pre-reorganisation issuer, so it belongs to the old entity.
+
+    Without the marker stripped this fell into `_미상/`, splitting one 교육청's
+    ordinances across two roots.
+    """
     xml = SAMPLE_XML.replace("서울특별시</지자체기관명>", "(구)전라남도교육청</지자체기관명>")
 
     path, markdown = converter.xml_to_markdown(xml)
 
-    assert path == "_미상/(구)전라남도교육청/조례/서울특별시 테스트 조례/본문.md"
+    assert path == "전라남도/_교육청/조례/서울특별시 테스트 조례/본문.md"
     assert _frontmatter(markdown)["지자체구분"] == {
-        "광역": "_미상",
-        "기초": "(구)전라남도교육청",
+        "광역": "전라남도",
+        "기초": "_교육청",
     }
 
 


### PR DESCRIPTION
## 현상

행정구역 개편 후 발령된 자치법규 중 일부가 `_미상/` 아래에 쌓인다. 한 기관의 자치법규가 정본 경로와 `_미상` 두 갈래로 갈린다.

```
_미상/(구)전라남도/조례/…/본문.md
_미상/(구)광주광역시교육청/훈령/…/본문.md
```

`전라남도`와 `광주광역시`는 `GWANGYEOK`에 이미 있으므로, 같은 기관의 다른 자치법규는 정상 경로에 있다. 즉 한 발령기관이 두 위치로 쪼개진다.

## 원인

law.go.kr은 개편 전 발령기관을 `(구)전라남도`처럼 표기한다. `GWANGYEOK`에 이 표기가 없으니 `split_jurisdiction`이 `UnknownJurisdiction`을 던지고, `converter`의 폴백이 이를 `_미상/` 버킷으로 보낸다.

```python
>>> split_jurisdiction("(구)전라남도")
UnknownJurisdiction: (구)전라남도
```

폴백 덕에 레코드가 유실되지는 않지만, 경로가 틀리면 컴파일 산출물의 디렉토리 구조가 어긋난다.

## 수정

`_normalize()`에서 선두 `(구)` 접두를 제거해 옛 명칭으로 해석한다.

```python
text = re.sub(r"^\s*\(\s*구\s*\)\s*", "", text)
```

- `^` 앵커를 써서 **이름 중간의 `(구)`는 건드리지 않는다** (예: `문경시 (구)쌍용양회 문경공장 부지 관리 조례`)
- `\s*`를 넣어 `( 구 )`, ` (구)` 같은 표기 흔들림도 흡수한다
- 개편 전 자치법규는 개편 전 주체의 것이므로 옛 명칭이 의미상으로도 맞다

`compiler`의 `ordinances/src/main.rs`에도 같은 규칙이 필요하다 — 별도 PR로 올린다. 두 구현이 어긋나면 같은 자치법규가 서로 다른 정본 경로에 놓인다.

## 테스트

기존 `test_xml_to_markdown_preserves_unknown_jurisdiction_under_fallback_path`가 `(구)전라남도교육청`을 `_미상/` 폴백의 예시로 쓰고 있었다. 이 예시는 이제 정상 해석되므로 **진짜 미등록 지자체(`없는광역시 어딘가구`)로 바꿔 폴백 커버리지를 그대로 유지**하고, `(구)` 해석을 검증하는 테스트를 새로 추가했다.

```python
def test_xml_to_markdown_resolves_former_jurisdiction_marker():
    ...
    assert path == "전라남도/_교육청/조례/서울특별시 테스트 조례/본문.md"
    assert _frontmatter(markdown)["지자체구분"] == {"광역": "전라남도", "기초": "_교육청"}
```

회귀 확인 케이스도 직접 돌렸다.

```
(구)전라남도            → ('전라남도', '_본청')
(구)광주광역시교육청     → ('광주광역시', '_교육청')
( 구 ) 전라남도 여수시   → ('전라남도', '여수시')
광주광역시 동구(구)      → ('광주광역시', '동구(구)')   ← 중간 (구) 보존
광주광역시 동구          → ('광주광역시', '동구')
전라남도 여수시          → ('전라남도', '여수시')
충청광역연합            → ('충청광역연합', '_본청')
강원도 춘천시           → ('강원특별자치도', '춘천시')   ← 기존 별칭 무회귀
전라북도 전주시         → ('전북특별자치도', '전주시')
제주도교육청            → ('제주특별자치도', '_교육청')
```

## 결과

실제 수집에서 해당 자치법규가 정본 경로로 들어간다. 캐시 재임포트로 확인한 결과다.

```
지자체기관명: '(구)전라남도'
지자체구분:
  광역: '전라남도'
  기초: '_본청'
→ 전라남도/_본청/조례/전라남도 유통분쟁조정위원회 구성 및 운영에 관한 조례/본문.md
```

`tests/test_ordinances/` 92 passed, 0 failed.