### PR TITLE
fix(tests): 테스트가 공유 원장을 오염시키는 문제

### DIFF
--- a/core/quota_budget.py
+++ b/core/quota_budget.py
@@ -31,7 +31,8 @@ def today_key() -> str:
     return datetime.now().strftime("%Y-%m-%d")
 
 
-def load(path: Path = STATE_FILE) -> dict:
+def load(path: Path | None = None) -> dict:
+    path = path or STATE_FILE
     if not path.exists():
         return {}
     try:
@@ -40,7 +41,8 @@ def load(path: Path = STATE_FILE) -> dict:
         return {}
 
 
-def record_requests(count: int, *, corpus: str, path: Path = STATE_FILE) -> None:
+def record_requests(count: int, *, corpus: str, path: Path | None = None) -> None:
+    path = path or STATE_FILE
     data = load(path)
     day = today_key()
     data.setdefault(day, {})
@@ -49,7 +51,7 @@ def record_requests(count: int, *, corpus: str, path: Path = STATE_FILE) -> None
     atomic_write_text(path, json.dumps(data, ensure_ascii=False, indent=2))
 
 
-def used_today(path: Path = STATE_FILE) -> int:
+def used_today(path: Path | None = None) -> int:
     return sum(int(value) for value in load(path).get(today_key(), {}).values())
 
 
@@ -58,7 +60,7 @@ def ensure_headroom(
     expected_requests: int,
     corpus: str,
     daily_budget: float = DEFAULT_DAILY_BUDGET,
-    path: Path = STATE_FILE,
+    path: Path | None = None,
     min_headroom_ratio: float = 0.30,
 ) -> None:
     if math.isinf(daily_budget):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,15 +51,46 @@ def _guard_against_shared_cache_pollution():
     / `foo법` invariant violation. This fixture snapshots the cache dirs at
     session start and diffs at teardown.
     """
+    import core.quota_budget as quota_budget
+
+    import admrules.cache as adm_cache
+    import admrules.checkpoint as adm_checkpoint
     import laws.cache as law_cache
+    import laws.failures as law_failures
+    import ordinances.cache as ord_cache
+    import ordinances.checkpoint as ord_checkpoint
     import precedents.cache as prec_cache
 
     guarded: list[tuple[str, Path]] = [
         ("laws.cache.CACHE_DIR/history", law_cache.CACHE_DIR / "history"),
         ("laws.cache.CACHE_DIR/detail", law_cache.CACHE_DIR / "detail"),
         ("precedents.cache.PREC_CACHE_DIR", prec_cache.PREC_CACHE_DIR),
+        ("admrules.cache.CACHE_DIR", adm_cache.CACHE_DIR),
+        ("ordinances.cache.CACHE_DIR", ord_cache.CACHE_DIR),
     ]
+    # Checkpoints are single files rather than directories, and are the kind of
+    # shared state that silently leaks between tests: a test that skips
+    # isolating them reads (or overwrites) the developer's live crawl state.
+    guarded_files: list[tuple[str, Path]] = [
+        ("admrules.checkpoint.CHECKPOINT_FILE", adm_checkpoint.CHECKPOINT_FILE),
+        ("ordinances.checkpoint.CHECKPOINT_FILE", ord_checkpoint.CHECKPOINT_FILE),
+        # 테스트가 실제 쿼터 원장에 허위 소비를 기록하면 그날의 수집이
+        # 가드레일에 막힐 수 있다.
+        ("core.quota_budget.STATE_FILE", quota_budget.STATE_FILE),
+        # 실패 원장은 CI 델타 게이트의 입력이다. 테스트가 남긴 항목은
+        # 다음 수집에서 신규 실패로 오보된다.
+        ("laws.failures.FAILED_FILE", law_failures.FAILED_FILE),
+    ]
+
+    def _snapshot_file(path: Path) -> tuple[int, int] | None:
+        try:
+            st = path.stat()
+        except OSError:
+            return None
+        return (st.st_size, st.st_mtime_ns)
+
     snapshots = [(label, d, _snapshot_dir(d)) for label, d in guarded]
+    file_snapshots = [(label, p, _snapshot_file(p)) for label, p in guarded_files]
 
     yield
 
@@ -74,6 +105,9 @@ def _guard_against_shared_cache_pollution():
                 f"{label} ({directory}): added={len(added)} changed={len(changed)}; "
                 f"examples={preview}"
             )
+    for label, path, before in file_snapshots:
+        if _snapshot_file(path) != before:
+            violations.append(f"{label} ({path}): mutated")
 
     if violations:
         raise AssertionError(
@@ -81,6 +115,22 @@ def _guard_against_shared_cache_pollution():
             "cache-writing code paths must monkeypatch the relevant CACHE_DIR "
             "to a tmp_path. Details:\n  - " + "\n  - ".join(violations)
         )
+
+
+@pytest.fixture(autouse=True)
+def _isolate_shared_ledgers(tmp_path, monkeypatch):
+    """Keep the shared ledgers out of every test's reach.
+
+    Both are reached indirectly from many code paths, so relying on each test to
+    stub them lets one omission corrupt developer state: a phantom day's
+    consumption blocks that day's fetch on the headroom guardrail, and a stray
+    failure entry is reported as a new regression by the CI delta gate.
+    """
+    import core.quota_budget as quota_budget
+    import laws.failures as law_failures
+
+    monkeypatch.setattr(quota_budget, "STATE_FILE", tmp_path / "quota.json")
+    monkeypatch.setattr(law_failures, "FAILED_FILE", tmp_path / "failed_msts.json")
 
 
 @pytest.fixture


### PR DESCRIPTION
## 현상

`pytest` 실행만으로 개발자의 실제 `.cache` 상태가 바뀐다.

**쿼터 원장** — 전체 스위트 1회당 그날의 소비가 누적된다.

```
$ md5sum .cache/law_api_quota_budget.json   # 실행 전
0b82bfc4...
$ pytest -q   →  686 passed
$ md5sum .cache/law_api_quota_budget.json   # 실행 후
4189c41b...        ← "ordinances" 6 → 7
```

원장이 없던 캐시에서도 새로 생성된다: `law_api_budget.json 45B {"...":{"ordinances":1}}`. 이 값이 쌓이면 그날의 실제 수집이 `ensure_headroom` 가드레일에 막힐 수 있다.

**실패 원장** — `.failed_msts.json`에도 항목이 남을 수 있다. 이 파일은 `laws._ci.delta_gate`의 입력이므로, 테스트가 남긴 항목은 다음 수집에서 **신규 실패로 오보**된다.

## 원인

두 가지가 겹쳤다.

**1. 경로가 기본 인자로 굳어 있다.** `core/quota_budget`의 함수들이 `path: Path = STATE_FILE`로 선언돼 있어 기본값이 import 시점에 바인딩된다. 테스트가 `quota_budget.STATE_FILE`을 monkeypatch해도 이미 굳은 기본값에는 영향이 없어 **격리 자체가 불가능**했다.

**2. 오염 가드에 사각이 있다.** `conftest.py`에 이미 `_guard_against_shared_cache_pollution`이 있지만 `laws.cache`/`precedents.cache` 세 경로만 감시한다. 나중에 추가된 `admrules`/`ordinances`와 두 원장은 감시 대상이 아니라, 오염이 조용히 통과했다.

## 수정

**`core/quota_budget.py`** — `load`/`record_requests`/`used_today`/`ensure_headroom`의 `path`를 `None` 기본값으로 바꾸고 호출 시점에 `STATE_FILE`을 읽는다. 명시적 `path=`를 넘기는 프로덕션 호출부는 없으므로(전수 확인: `ordinances/fetch_cache.py` 9곳, `admrules/fetch_cache.py` 3곳 모두 생략) 시그니처 변경 영향이 없다.

**`tests/conftest.py`** — 예방과 탐지를 함께 둔다.

- autouse 픽스처 `_isolate_shared_ledgers`가 두 원장을 `tmp_path`로 돌린다. 개별 테스트가 stub을 빠뜨려도 실 파일에 닿지 않는다
- 세션 가드 감시 대상에 `admrules.cache.CACHE_DIR`, `ordinances.cache.CACHE_DIR`, 두 corpus의 체크포인트, 두 원장을 추가한다. 예방이 뚫려도 세션 종료 시 실패로 드러난다

## 테스트

**감도 대조** — 동일 조건 미러 워크스페이스에서 수정 전후를 비교했다.

| 트리 | pytest | 원장 md5 |
|---|---|---|
| 수정 전 | 686 passed | `0b82bfc4…` → **`4189c41b…` 변조** |
| 수정 후 | 686 passed | `0b82bfc4…` → **불변** |

원장이 없던 캐시에서도 수정 후에는 파일이 생성되지 않는다(`No such file or directory`).

**가드 발화 확인** — 의도적으로 오염시키는 테스트를 넣어 실행했다.

```
AssertionError: Tests mutated shared on-disk caches ...
  - core.quota_budget.STATE_FILE (…/law_api_quota_budget.json): mutated
  - ordinances.cache.CACHE_DIR (…): added=1 examples=['POLLUTED.json']
  - ordinances.checkpoint.CHECKPOINT_FILE (…): mutated
```

수정 전 트리에서는 같은 오염이 통과한다(`1 passed`).

**시그니처 동등성** — 명시 `path`와 생략 각각 올바른 파일을 쓰는지 확인했다.

```
default-path file  {"...": {"laws": 7}}   used_today() = 7
explicit file      {"...": {"laws": 3}}   used_today(explicit) = 3, default 불변 = 7
redirected file    {"...": {"admrules": 5}}   ← from-import 바인딩도 런타임 STATE_FILE 추종
ensure_headroom(explicit) → RuntimeError: laws fetch would exceed quota guardrail: used=3 expected=100 budget=10
```

## 결과

673 passed, 0 failed. 실행 전후 실 원장 md5·size·mtime 불변.

기존 테스트는 하나도 수정하지 않았다 — 격리는 conftest 한 곳에서만 이뤄지므로 개별 테스트가 stub을 빠뜨려도 안전해진다.