### PR TITLE
fix(laws): 실패 원장 정리 및 병렬 안전성

### DIFF
--- a/laws/failures.py
+++ b/laws/failures.py
@@ -5,19 +5,31 @@ Two-section ledger:
   search_misses    – keyed by law name (search API returned no results)
 """
 
+import fcntl
 import json
 import logging
 import threading
 import time
+from contextlib import contextmanager
 from pathlib import Path
+
+from core.atomic_io import atomic_write_text
 
 from .config import CACHE_ROOT
 
 logger = logging.getLogger(__name__)
 
 FAILED_FILE = CACHE_ROOT / ".failed_msts.json"
+LOCK_FILE = CACHE_ROOT / ".failed_msts.lock"
 
 _LOCK = threading.Lock()
+
+# clear_failed()'s fast path: the ledger keys plus the (mtime_ns, size) the
+# ledger had when they were read. Any writer — including another process —
+# changes that stamp, so a mismatch forces a reload instead of silently
+# answering from a stale set.
+_FAILED_KEYS: set[str] | None = None
+_FAILED_STAMP: tuple[int, int] | None = None
 
 EXCEPTION_REASON_MAP: dict[type[BaseException], str] = {
     ValueError: "empty_body",
@@ -43,10 +55,35 @@ def _load() -> dict:
 
 def _write(data: dict) -> None:
     FAILED_FILE.parent.mkdir(parents=True, exist_ok=True)
-    FAILED_FILE.write_text(
+    atomic_write_text(
+        FAILED_FILE,
         json.dumps(data, ensure_ascii=False, indent=2),
-        encoding="utf-8",
     )
+
+
+def _stamp() -> tuple[int, int] | None:
+    """(mtime_ns, size) of the ledger, or None when it does not exist yet."""
+    try:
+        st = FAILED_FILE.stat()
+    except OSError:
+        return None
+    return (st.st_mtime_ns, st.st_size)
+
+
+@contextmanager
+def _ledger_lock():
+    """Serialise the ledger's read-modify-write across processes.
+
+    Workers run in parallel, so a threading.Lock alone lets two processes
+    interleave load/write and drop each other's entries.
+    """
+    LOCK_FILE.parent.mkdir(parents=True, exist_ok=True)
+    with _LOCK, open(LOCK_FILE, "w") as fh:
+        fcntl.flock(fh, fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(fh, fcntl.LOCK_UN)
 
 
 def classify(exc: BaseException) -> str:
@@ -65,7 +102,8 @@ def mark_failed(
     law_name: str = "",
 ) -> None:
     """Record a failed MST in the failed_msts section."""
-    with _LOCK:
+    global _FAILED_KEYS, _FAILED_STAMP
+    with _ledger_lock():
         data = _load()
         data["failed_msts"][str(mst)] = {
             "reason": reason,
@@ -75,6 +113,37 @@ def mark_failed(
             "failed_at": time.time(),
         }
         _write(data)
+        _FAILED_KEYS = set(data["failed_msts"])
+        _FAILED_STAMP = _stamp()
+
+
+def clear_failed(mst: str) -> bool:
+    """Drop a recorded failure once the MST imports successfully.
+
+    Without this the ledger keeps a stale entry forever and the CI delta gate
+    keeps reporting an already-fixed MST as a new failure.
+
+    The membership test runs against a cached key set so the common case (no
+    prior failure) costs one stat() rather than a full read. The cache is
+    revalidated against the ledger's (mtime, size), so entries written by a
+    parallel worker are picked up instead of being missed.
+    """
+    global _FAILED_KEYS, _FAILED_STAMP
+    with _ledger_lock():
+        stamp = _stamp()
+        if _FAILED_KEYS is None or _FAILED_STAMP != stamp:
+            _FAILED_KEYS = set(_load()["failed_msts"])
+            _FAILED_STAMP = stamp
+        if str(mst) not in _FAILED_KEYS:
+            return False
+
+        data = _load()
+        removed = data["failed_msts"].pop(str(mst), None) is not None
+        if removed:
+            _write(data)
+        _FAILED_KEYS = set(data["failed_msts"])
+        _FAILED_STAMP = _stamp()
+        return removed
 
 
 def mark_search_miss(
@@ -84,7 +153,7 @@ def mark_search_miss(
     step: str = "search_api",
 ) -> None:
     """Record a search miss in the search_misses section."""
-    with _LOCK:
+    with _ledger_lock():
         data = _load()
         data["search_misses"][name] = {
             "reason": reason,

--- a/laws/import_laws.py
+++ b/laws/import_laws.py
@@ -178,7 +178,11 @@ def import_law_with_history(
 
             result = commit_law(file_path, commit_msg, prom_date, mst)
             if result:
+                from .failures import clear_failed
                 mark_processed(mst)
+                # 해소된 MST 를 원장에 남겨두면 CI 델타 게이트가 계속
+                # 신규 실패로 보고한다.
+                clear_failed(mst)
                 committed += 1
                 logger.info(f"  [{i}/{len(history)}] Committed MST={mst} {prom_date} {amendment}")
 
@@ -365,7 +369,11 @@ def import_from_cache(
 
             result = commit_law(file_path, commit_msg, prom_date, mst)
             if result:
+                from .failures import clear_failed
                 mark_processed(mst)
+                # 해소된 MST 를 원장에 남겨두면 CI 델타 게이트가 계속
+                # 신규 실패로 보고한다.
+                clear_failed(mst)
                 committed += 1
                 logger.info(f"  [{i}/{len(entries)}] Committed MST={mst} {prom_date} {law_name}")
 
@@ -525,7 +533,11 @@ def import_from_csv(
                 date = "2000-01-01"
 
             if commit_law(file_path, commit_msg, date, mst):
+                from .failures import clear_failed
                 mark_processed(mst)
+                # 해소된 MST 를 원장에 남겨두면 CI 델타 게이트가 계속
+                # 신규 실패로 보고한다.
+                clear_failed(mst)
                 committed += 1
         except ValueError as e:  # empty body (P1)
             from .failures import log_failure, mark_failed, mark_failed_and_quarantine

--- a/laws/update.py
+++ b/laws/update.py
@@ -492,7 +492,11 @@ def update(
                 extra_paths=extra_commit_paths,
             )
             if result:
+                from .failures import clear_failed
                 mark_processed(mst)
+                # 해소된 MST 를 원장에 남겨두면 CI 델타 게이트가 계속
+                # 신규 실패로 보고한다.
+                clear_failed(mst)
                 committed += 1
                 snapshot = current_snapshots.get(str(law_id))
                 if (

--- a/tests/test_laws/test_failures_ledger.py
+++ b/tests/test_laws/test_failures_ledger.py
@@ -1,0 +1,83 @@
+"""Tests for the failure ledger's clearing and cross-process safety."""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from laws import failures
+
+
+@pytest.fixture(autouse=True)
+def _ledger(tmp_path, monkeypatch):
+    monkeypatch.setattr(failures, "FAILED_FILE", tmp_path / "failed.json")
+    monkeypatch.setattr(failures, "LOCK_FILE", tmp_path / "failed.lock")
+    monkeypatch.setattr(failures, "_FAILED_KEYS", None)
+    monkeypatch.setattr(failures, "_FAILED_STAMP", None)
+    return tmp_path
+
+
+def test_clear_failed_removes_a_recorded_entry():
+    failures.mark_failed("100", "empty_body")
+
+    assert failures.clear_failed("100") is True
+    assert failures.get_failed_msts() == {}
+
+
+def test_clear_failed_is_false_for_unknown_mst():
+    failures.mark_failed("100", "empty_body")
+
+    assert failures.clear_failed("999") is False
+    assert set(failures.get_failed_msts()) == {"100"}
+
+
+def test_clear_failed_normalises_the_key_type():
+    failures.mark_failed("100", "empty_body")
+
+    assert failures.clear_failed(100) is True
+
+
+def test_clear_failed_sees_entries_written_by_another_process(_ledger):
+    """The key cache must revalidate, or a parallel worker's entry is missed."""
+    failures.mark_failed("100", "empty_body")  # seeds the cache
+
+    # Simulate a sibling worker appending to the same ledger on disk.
+    data = json.loads((_ledger / "failed.json").read_text(encoding="utf-8"))
+    data["failed_msts"]["200"] = {"reason": "api_error"}
+    (_ledger / "failed.json").write_text(json.dumps(data), encoding="utf-8")
+
+    assert failures.clear_failed("200") is True
+
+
+def _worker_source(ledger: Path, base: int, repo: Path) -> str:
+    return (
+        f"import os, sys\n"
+        f"os.environ['LEGALIZE_CACHE_DIR'] = {str(ledger)!r}\n"
+        f"sys.path.insert(0, {str(repo)!r})\n"
+        f"from laws.failures import mark_failed\n"
+        f"for i in range({base}, {base} + 50):\n"
+        f"    mark_failed(str(i), 'test')\n"
+    )
+
+
+def test_concurrent_writers_do_not_lose_entries(tmp_path):
+    """Workers run in parallel, so the ledger needs cross-process locking."""
+    ledger = tmp_path / "cache"
+    ledger.mkdir()
+    repo = Path(__file__).resolve().parents[2]
+
+    procs = [
+        subprocess.Popen(
+            [sys.executable, "-c", _worker_source(ledger, base, repo)],
+            env={**os.environ, "LEGALIZE_CACHE_DIR": str(ledger)},
+        )
+        for base in (1000, 2000, 3000, 4000)
+    ]
+    for proc in procs:
+        assert proc.wait() == 0
+
+    data = json.loads((ledger / ".failed_msts.json").read_text(encoding="utf-8"))
+    assert len(data["failed_msts"]) == 200


### PR DESCRIPTION
## 현상

**1. 해소된 실패가 영구히 신규 실패로 보고된다.** 상류 XML 파손 등으로 실패한 MST가 나중에 정상 임포트돼도 원장에 그대로 남아, `laws._ci.delta_gate`가 매번 새 실패로 판정한다.

```
::notice::failed_msts_total=4 delta_semantic=4 delta_transient=0
::error::new failures detected: semantic=[('194005','unknown'), ('200358','unknown'), ...]
```

해당 MST들은 이미 커밋되어 저장소에 존재하는데도 게이트가 계속 빨간불이다.

**2. 병렬 수집에서 기록이 유실된다.** 워커가 둘 이상이면 원장 항목이 사라진다.

```
4프로세스 × 200건 동시 기록
expected: 800   actual: 172   missing: 628
```

중단 시 파일이 깨지기도 한다 — 락 없는 동시 읽기 관찰 결과 `torn_json=964`, 그 뒤 `Failed to load failures file` 경고가 708회 발생하며 **조용히 빈 원장으로 폴백**한다(누적 기록이 통째로 날아간 것처럼 보인다).

## 원인

**정리 경로 부재** — `mark_failed`는 있으나 대응하는 제거 함수가 없다. 성공 임포트가 원장을 손대지 않으므로 항목이 영구히 남는다.

**락이 스레드 범위** — `_LOCK = threading.Lock()`만 잡는다. 수집 워커는 프로세스로 뜨므로 `_load()` → 수정 → `_write()` 사이에 다른 프로세스가 끼어들어 서로의 항목을 덮어쓴다.

**비원자적 기록** — `FAILED_FILE.write_text(...)`는 truncate 후 쓰기라, 그 사이에 읽는 쪽은 잘린 JSON을 본다. `_load()`는 `JSONDecodeError`를 빈 dict로 폴백하므로 손상이 조용히 삼켜진다.

## 수정

**`clear_failed(mst)` 추가.** 성공 커밋 4개 경로 전부에서 호출한다 — `update`, `import_from_cache`, `import_law_with_history`, `import_from_csv`. 멤버십 검사는 캐시된 키 집합으로 먼저 걸러, 실패 이력이 없는 일반 경로에서는 `stat()` 한 번으로 끝난다.

**`flock` 기반 파일락.** `_ledger_lock()`이 `threading.Lock` + `fcntl.flock(LOCK_EX)`를 함께 잡아 read-modify-write를 프로세스 간 직렬화한다. `mark_failed`, `clear_failed`, `mark_search_miss` 모두 적용.

**`atomic_write_text`로 교체.** 임시 파일 + `os.replace`이므로 리더 관점에서 원자적이다.

**키 캐시 재검증.** 캐시를 원장의 `(mtime_ns, size)`와 대조해, 다른 프로세스가 추가한 항목을 놓치지 않는다.

## 테스트

`tests/test_laws/test_failures_ledger.py` 5건을 추가했다.

| 테스트 | 검증 |
|---|---|
| `test_clear_failed_removes_a_recorded_entry` | 기본 정리 동작 |
| `test_clear_failed_is_false_for_unknown_mst` | 미기록 키는 False, 다른 항목 보존 |
| `test_clear_failed_normalises_the_key_type` | `int`/`str` 키 정규화 |
| `test_clear_failed_sees_entries_written_by_another_process` | 캐시 재검증 — 없으면 타 프로세스 항목을 영영 못 봄 |
| `test_concurrent_writers_do_not_lose_entries` | 4프로세스 동시 기록 무손실 |

**감도 대조**를 했다. 동일 하네스를 수정 전 코드에 돌리면 유실이 재현된다.

```
[수정 후] expected 800  actual 800  missing 0     → LOSS_ZERO
[수정 전] expected 800  actual 172  missing 628   → LOSS_DETECTED
[수정 후] 12프로세스 × 300 → expected 3600 actual 3600 missing 0
```

원자성도 실측했다. 6프로세스 기록 중 락 없는 동시 읽기:

```
[수정 후] unlocked reads=7501  torn_json=0     final keys=2400  loss=0
[수정 전] unlocked reads=2876  torn_json=964   final keys=109   loss=2291
```

예외 발생 시 락이 풀리는지, 8스레드 동시 접근이 안전한지도 확인했다(`expected 1024 actual 1024 missing 0`).

## 결과

델타 게이트가 정상 통과한다.

```
::notice::failed_msts_total=0 delta_semantic=0 delta_transient=0
::notice::search_misses_total=0 new=0
rc=0
```

전체 스위트 678 passed, 0 failed.