### PR TITLE
fix(laws): import 경로의 HEAD 퇴행 방지

### DIFF
--- a/laws/git_engine.py
+++ b/laws/git_engine.py
@@ -1,3 +1,4 @@
+import re
 from pathlib import Path
 
 from core.git_engine import _run_git as _core_run_git
@@ -7,6 +8,45 @@ from .config import BOT_AUTHOR, LAW_REPO
 
 def _run_git(*args: str, env: dict | None = None) -> str:
     return _core_run_git(*args, cwd=LAW_REPO, env=env)
+
+
+# YAML scalars reach us quoted or bare depending on which writer produced the
+# file, so strip a matching pair of quotes rather than trusting either form.
+_FRONTMATTER_VALUE = r"^{key}:\s*(?:'([^']*)'|\"([^\"]*)\"|(\S+))\s*$"
+
+
+def _frontmatter_value(blob: str, key: str) -> str | None:
+    match = re.search(_FRONTMATTER_VALUE.format(key=re.escape(key)), blob, re.M)
+    if not match:
+        return None
+    return next((g for g in match.groups() if g is not None), "")
+
+
+def head_law_version(file_path: str) -> tuple[str, str, str] | None:
+    """(공포일자, 공포번호, 법령MST) of ``file_path`` at HEAD, or None.
+
+    공포일자 comes back without separators (YYYYMMDD) so it orders directly
+    against the raw API value. 공포번호 is the tie-breaker for same-day
+    amendments, matching the canonical ingestion order.
+
+    Every field is read through _FRONTMATTER_VALUE: build_csv_markdown emits
+    quoted scalars (``공포일자: '2024-01-15'``) while the API path emits bare
+    ones, and a stray quote sorts below every digit — which would silently
+    park the HEAD baseline at the bottom and defeat the regression guard.
+    """
+    try:
+        blob = _run_git("show", f"HEAD:{file_path}")
+    except RuntimeError:
+        return None
+    prom = _frontmatter_value(blob, "공포일자")
+    mst = _frontmatter_value(blob, "법령MST")
+    if prom is None or mst is None:
+        return None
+    return (
+        prom.replace("-", ""),
+        _frontmatter_value(blob, "공포번호") or "",
+        mst,
+    )
 
 
 def commit_law(

--- a/laws/git_engine.py
+++ b/laws/git_engine.py
@@ -35,12 +35,16 @@ def head_law_snapshot(file_path: str) -> tuple[tuple[str, str, str], str] | None
     ones, and a stray quote sorts below every digit — which would silently
     park the HEAD baseline at the bottom and defeat the regression guard.
     """
-    result = subprocess.run(
-        ["git", "show", f"HEAD:{file_path}"],
-        cwd=LAW_REPO,
-        capture_output=True,
-        text=True,
-    )
+    try:
+        result = subprocess.run(
+            ["git", "show", f"HEAD:{file_path}"],
+            cwd=LAW_REPO,
+            capture_output=True,
+            text=True,
+        )
+    except OSError:
+        # Tests and first-run imports may not have a materialized law repo yet.
+        return None
     if result.returncode != 0:
         return None
     blob = result.stdout

--- a/laws/git_engine.py
+++ b/laws/git_engine.py
@@ -1,4 +1,5 @@
 import re
+import subprocess
 from pathlib import Path
 
 from core.git_engine import _run_git as _core_run_git
@@ -22,8 +23,8 @@ def _frontmatter_value(blob: str, key: str) -> str | None:
     return next((g for g in match.groups() if g is not None), "")
 
 
-def head_law_version(file_path: str) -> tuple[str, str, str] | None:
-    """(공포일자, 공포번호, 법령MST) of ``file_path`` at HEAD, or None.
+def head_law_snapshot(file_path: str) -> tuple[tuple[str, str, str], str] | None:
+    """Return HEAD's version tuple and exact Markdown for ``file_path``.
 
     공포일자 comes back without separators (YYYYMMDD) so it orders directly
     against the raw API value. 공포번호 is the tie-breaker for same-day
@@ -34,19 +35,33 @@ def head_law_version(file_path: str) -> tuple[str, str, str] | None:
     ones, and a stray quote sorts below every digit — which would silently
     park the HEAD baseline at the bottom and defeat the regression guard.
     """
-    try:
-        blob = _run_git("show", f"HEAD:{file_path}")
-    except RuntimeError:
+    result = subprocess.run(
+        ["git", "show", f"HEAD:{file_path}"],
+        cwd=LAW_REPO,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
         return None
+    blob = result.stdout
     prom = _frontmatter_value(blob, "공포일자")
     mst = _frontmatter_value(blob, "법령MST")
     if prom is None or mst is None:
         return None
     return (
-        prom.replace("-", ""),
-        _frontmatter_value(blob, "공포번호") or "",
-        mst,
+        (
+            prom.replace("-", ""),
+            _frontmatter_value(blob, "공포번호") or "",
+            mst,
+        ),
+        blob,
     )
+
+
+def head_law_version(file_path: str) -> tuple[str, str, str] | None:
+    """(공포일자, 공포번호, 법령MST) of ``file_path`` at HEAD, or None."""
+    snapshot = head_law_snapshot(file_path)
+    return snapshot[0] if snapshot else None
 
 
 def commit_law(

--- a/laws/import_laws.py
+++ b/laws/import_laws.py
@@ -30,7 +30,7 @@ from .converter import (
     plan_current_law_paths,
     reset_path_registry,
 )
-from .git_engine import commit_law
+from .git_engine import commit_law, head_law_version
 
 logger = logging.getLogger(__name__)
 
@@ -38,6 +38,90 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 # Commit message builder
 # ---------------------------------------------------------------------------
+
+def _as_int(value: str) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+class VersionTracker:
+    """Keeps HEAD pointing at each file's newest law version.
+
+    Backfilled MSTs are older than versions committed by earlier runs, so
+    committing them overwrites the file and leaves HEAD serving stale law text
+    (the file's history keeps every version, but its tip regresses). Seed from
+    HEAD on first touch, record every commit, then restore whatever ended up
+    behind.
+    """
+
+    def __init__(self) -> None:
+        # file_path -> (공포일자, 공포번호, MST)
+        self.newest: dict[str, tuple[str, str, str]] = {}
+        self.current: dict[str, tuple[str, str, str]] = {}
+
+    @staticmethod
+    def _order(version: tuple[str, str, str]) -> tuple[str, int, int]:
+        """Rank a version the same way the canonical ingestion sort does.
+
+        Same-day amendments are ordered by 공포번호 then MST, so a same-date
+        backfill no longer reads as "not a regression".
+        """
+        prom, num, mst = version
+        return (prom, _as_int(num), _as_int(mst))
+
+    def seen(self, file_path: str) -> None:
+        """Seed a file's baseline from HEAD the first time it is touched."""
+        if file_path in self.newest:
+            return
+        head = head_law_version(file_path)
+        if head:
+            self.newest[file_path] = head
+            self.current[file_path] = head
+
+    def committed(self, file_path: str, meta: dict, mst: str) -> None:
+        version = (
+            (meta.get("공포일자", "") or "").replace("-", ""),
+            str(meta.get("공포번호", "") or ""),
+            str(mst),
+        )
+        self.current[file_path] = version
+        known = self.newest.get(file_path)
+        if known is None or self._order(version) > self._order(known):
+            self.newest[file_path] = version
+
+    def regressed(self) -> list[tuple[str, str, str]]:
+        """(file_path, newest_mst, held_공포일자) for files left behind."""
+        out = []
+        for path, want in sorted(self.newest.items()):
+            have = self.current.get(path)
+            if have is not None and self._order(have) < self._order(want):
+                out.append((path, want[2], have[0]))
+        return out
+
+    def restore(self) -> int:
+        """Re-commit the newest version wherever HEAD regressed."""
+        restored = 0
+        for path, mst, held in self.regressed():
+            logger.warning("HEAD regressed for %s (holds %s) — restoring MST=%s", path, held, mst)
+            try:
+                detail = get_law_detail(mst)
+                meta = detail["metadata"]
+                (KR_DIR.parent / path).write_text(law_to_markdown(detail), encoding="utf-8")
+                msg = build_commit_msg(
+                    meta.get("법령명한글", ""), meta.get("법령구분", ""), mst, meta
+                )
+                prom = format_date(meta.get("공포일자", "")) or "2000-01-01"
+                if commit_law(path, msg, prom, mst, skip_dedup=True):
+                    restored += 1
+                    logger.info("  Restored MST=%s %s %s", mst, prom, path)
+            except Exception as e:
+                from .failures import log_failure
+                log_failure("restore_newest", str(mst), path, e)
+                logger.error("Restore failed for %s: %s", path, e)
+        return restored
+
 
 def build_commit_msg(law_name: str, law_type: str, mst: str, meta: dict) -> str:
     """Build a rich commit message with law.go.kr URLs and metadata."""
@@ -133,6 +217,7 @@ def import_law_with_history(
     processed = get_processed_msts()
     committed = 0
     errors = 0
+    tracker = VersionTracker()
 
     for i, entry in enumerate(history, 1):
         mst = entry["법령일련번호"]
@@ -153,6 +238,8 @@ def import_law_with_history(
             law_id = meta.get("법령ID", "")
             file_path = get_law_path(fetched_name, law_type_name, law_id)
             abs_path = KR_DIR.parent / file_path
+            if not dry_run:
+                tracker.seen(file_path)
 
             # Merge history metadata into detail metadata
             meta["제개정구분"] = entry.get("제개정구분명", meta.get("제개정구분", ""))
@@ -180,6 +267,7 @@ def import_law_with_history(
             if result:
                 mark_processed(mst)
                 committed += 1
+                tracker.committed(file_path, meta, mst)
                 logger.info(f"  [{i}/{len(history)}] Committed MST={mst} {prom_date} {amendment}")
 
         except ValueError as e:  # empty body (P1)
@@ -202,7 +290,11 @@ def import_law_with_history(
                         step="import_law_with_history", law_name=law_name)
             errors += 1
 
-    logger.info(f"History import for {law_name}: committed={committed}, errors={errors}")
+    restored = tracker.restore() if not dry_run else 0
+    logger.info(
+        f"History import for {law_name}: committed={committed}, "
+        f"restored={restored}, errors={errors}"
+    )
     return committed
 
 
@@ -338,6 +430,7 @@ def import_from_cache(
 
     committed = 0
     errors = 0
+    tracker = VersionTracker()
 
     for i, (mst, detail) in enumerate(entries, 1):
         meta = detail["metadata"]
@@ -350,6 +443,8 @@ def import_from_cache(
             file_path = planned_paths.get(mst) or get_law_path(law_name, law_type, law_id)
             abs_path = KR_DIR.parent / file_path
             prom_date = format_date(meta.get("공포일자", ""))
+            if not dry_run:
+                tracker.seen(file_path)
 
             if dry_run:
                 logger.info(f"  [{i}/{len(entries)}] [DRY-RUN] MST={mst} {prom_date} {law_name} -> {file_path}")
@@ -367,6 +462,7 @@ def import_from_cache(
             if result:
                 mark_processed(mst)
                 committed += 1
+                tracker.committed(file_path, meta, mst)
                 logger.info(f"  [{i}/{len(entries)}] Committed MST={mst} {prom_date} {law_name}")
 
         except ValueError as e:  # empty body (P1)
@@ -392,7 +488,10 @@ def import_from_cache(
         if i % 100 == 0:
             logger.info(f"Progress: {i}/{len(entries)} (committed={committed}, errors={errors})")
 
-    logger.info(f"Cache import done: committed={committed}, errors={errors}")
+    restored = tracker.restore() if not dry_run else 0
+    logger.info(
+        f"Cache import done: committed={committed}, restored={restored}, errors={errors}"
+    )
     return committed
 
 
@@ -502,6 +601,7 @@ def import_from_csv(
         laws = laws[:limit]
 
     committed = 0
+    tracker = VersionTracker()
     for i, law in enumerate(laws, 1):
         mst = law["법령MST"]
         name = law["법령명"]
@@ -516,6 +616,7 @@ def import_from_csv(
                 logger.info(f"[DRY-RUN] {file_path}")
                 continue
 
+            tracker.seen(file_path)
             abs_path.parent.mkdir(parents=True, exist_ok=True)
             abs_path.write_text(build_csv_markdown(law), encoding="utf-8")
 
@@ -527,6 +628,7 @@ def import_from_csv(
             if commit_law(file_path, commit_msg, date, mst):
                 mark_processed(mst)
                 committed += 1
+                tracker.committed(file_path, law, mst)
         except ValueError as e:  # empty body (P1)
             from .failures import log_failure, mark_failed, mark_failed_and_quarantine
             log_failure("import_from_csv", str(mst), name, e)
@@ -548,7 +650,8 @@ def import_from_csv(
         if i % 100 == 0:
             logger.info(f"Progress: {i}/{len(laws)} (committed={committed})")
 
-    logger.info(f"CSV import done: committed={committed}")
+    restored = tracker.restore() if not dry_run else 0
+    logger.info(f"CSV import done: committed={committed}, restored={restored}")
     return committed
 
 

--- a/laws/import_laws.py
+++ b/laws/import_laws.py
@@ -30,7 +30,7 @@ from .converter import (
     plan_current_law_paths,
     reset_path_registry,
 )
-from .git_engine import commit_law, head_law_version
+from .git_engine import commit_law, commit_law_changes, head_law_snapshot
 
 logger = logging.getLogger(__name__)
 
@@ -60,6 +60,7 @@ class VersionTracker:
         # file_path -> (공포일자, 공포번호, MST)
         self.newest: dict[str, tuple[str, str, str]] = {}
         self.current: dict[str, tuple[str, str, str]] = {}
+        self.content: dict[str, str] = {}
 
     @staticmethod
     def _order(version: tuple[str, str, str]) -> tuple[str, int, int]:
@@ -75,10 +76,12 @@ class VersionTracker:
         """Seed a file's baseline from HEAD the first time it is touched."""
         if file_path in self.newest:
             return
-        head = head_law_version(file_path)
-        if head:
+        snapshot = head_law_snapshot(file_path)
+        if snapshot:
+            head, content = snapshot
             self.newest[file_path] = head
             self.current[file_path] = head
+            self.content[file_path] = content
 
     def committed(self, file_path: str, meta: dict, mst: str) -> None:
         version = (
@@ -88,8 +91,11 @@ class VersionTracker:
         )
         self.current[file_path] = version
         known = self.newest.get(file_path)
-        if known is None or self._order(version) > self._order(known):
+        if known is None or self._order(version) >= self._order(known):
             self.newest[file_path] = version
+            content_path = KR_DIR.parent / file_path
+            if content_path.exists():
+                self.content[file_path] = content_path.read_text(encoding="utf-8")
 
     def regressed(self) -> list[tuple[str, str, str]]:
         """(file_path, newest_mst, held_공포일자) for files left behind."""
@@ -101,19 +107,18 @@ class VersionTracker:
         return out
 
     def restore(self) -> int:
-        """Re-commit the newest version wherever HEAD regressed."""
+        """Restore the exact newest HEAD snapshot wherever a backfill regressed it."""
         restored = 0
         for path, mst, held in self.regressed():
             logger.warning("HEAD regressed for %s (holds %s) — restoring MST=%s", path, held, mst)
             try:
-                detail = get_law_detail(mst)
-                meta = detail["metadata"]
-                (KR_DIR.parent / path).write_text(law_to_markdown(detail), encoding="utf-8")
-                msg = build_commit_msg(
-                    meta.get("법령명한글", ""), meta.get("법령구분", ""), mst, meta
-                )
-                prom = format_date(meta.get("공포일자", "")) or "2000-01-01"
-                if commit_law(path, msg, prom, mst, skip_dedup=True):
+                (KR_DIR.parent / path).write_text(self.content[path], encoding="utf-8")
+                prom = format_date(self.newest[path][0]) or "2000-01-01"
+                if commit_law_changes(
+                    [path],
+                    "chore(laws): 과거 이력 백필 후 최신 상태 복원",
+                    prom,
+                ):
                     restored += 1
                     logger.info("  Restored MST=%s %s %s", mst, prom, path)
             except Exception as e:

--- a/laws/rebuild.py
+++ b/laws/rebuild.py
@@ -134,7 +134,13 @@ def load_and_sort_entries() -> list[tuple[str, dict]]:
 
 
 def rebuild_law_commits(entries: list[tuple[str, dict]], dry_run: bool = False) -> int:
-    """Create one commit per law entry, oldest first."""
+    """Create one commit per law entry, oldest first.
+
+    Needs no VersionTracker (unlike update/import_from_cache): this replays
+    every cached version onto an orphan branch in canonical ascending order
+    with no dedup skip, so each file's newest version is always committed
+    last and HEAD cannot regress. Keep those two properties if editing.
+    """
     planned_paths = plan_current_law_paths(entries)
     committed = 0
     errors = 0

--- a/tests/test_laws/test_version_tracker.py
+++ b/tests/test_laws/test_version_tracker.py
@@ -1,0 +1,170 @@
+"""Tests for the HEAD-regression guard (laws.import_laws.VersionTracker).
+
+The guard had no coverage at all, which is how a quoting bug in
+``head_law_version`` reached main: ``build_csv_markdown`` writes
+``공포일자: '2024-01-15'`` while the API path writes it bare, and an unstripped
+quote sorts below every digit — parking the HEAD baseline at the bottom so no
+backfill ever looked like a regression.
+"""
+
+import subprocess
+
+import pytest
+
+from laws import git_engine
+from laws.import_laws import VersionTracker
+
+
+def _git(repo, *args):
+    subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True)
+
+
+def _frontmatter(mst: str, prom: str, num: str, *, quoted: bool) -> str:
+    q = "'" if quoted else ""
+    return (
+        "---\n"
+        f"법령MST: {mst}\n"
+        f"공포일자: {q}{prom}{q}\n"
+        f"공포번호: {q}{num}{q}\n"
+        "---\n\n본문\n"
+    )
+
+
+@pytest.fixture
+def law_repo(tmp_path, monkeypatch):
+    """A git repo standing in for legalize-kr, wired into laws.git_engine."""
+    repo = tmp_path / "legalize-kr"
+    (repo / "kr" / "민법").mkdir(parents=True)
+    _git(repo.parent, "init", "-q", "-b", "main", str(repo))
+    _git(repo, "config", "user.name", "t")
+    _git(repo, "config", "user.email", "t@t")
+    monkeypatch.setattr(git_engine, "LAW_REPO", repo)
+    return repo
+
+
+def _commit_version(repo, rel, mst, prom, num, *, quoted=False):
+    (repo / rel).write_text(_frontmatter(mst, prom, num, quoted=quoted), encoding="utf-8")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", f"법령MST: {mst}")
+
+
+@pytest.mark.parametrize("quoted", [False, True])
+def test_head_law_version_reads_quoted_and_bare_frontmatter(law_repo, quoted):
+    _commit_version(law_repo, "kr/민법/법률.md", "300", "2024-01-15", "00031", quoted=quoted)
+
+    assert git_engine.head_law_version("kr/민법/법률.md") == ("20240115", "00031", "300")
+
+
+def test_head_law_version_returns_none_for_unknown_path(law_repo):
+    _commit_version(law_repo, "kr/민법/법률.md", "300", "2024-01-15", "00031")
+
+    assert git_engine.head_law_version("kr/없는법/법률.md") is None
+
+
+@pytest.mark.parametrize("quoted", [False, True])
+def test_backfilling_an_older_version_is_flagged(law_repo, quoted):
+    """The core guard: an older MST committed over a newer HEAD must regress."""
+    _commit_version(law_repo, "kr/민법/법률.md", "300", "2024-01-15", "00031", quoted=quoted)
+
+    tracker = VersionTracker()
+    tracker.seen("kr/민법/법률.md")
+    tracker.committed("kr/민법/법률.md", {"공포일자": "19900101", "공포번호": "00001"}, "100")
+
+    assert tracker.regressed() == [("kr/민법/법률.md", "300", "19900101")]
+
+
+def test_same_date_lower_promulgation_number_is_a_regression(law_repo):
+    """MST 는 더 크지만 공포번호가 낮다 — 공포번호가 실제로 비교돼야 잡힌다."""
+    _commit_version(law_repo, "kr/민법/법률.md", "300", "2024-01-15", "00031")
+
+    tracker = VersionTracker()
+    tracker.seen("kr/민법/법률.md")
+    tracker.committed("kr/민법/법률.md", {"공포일자": "20240115", "공포번호": "00030"}, "301")
+
+    assert [p for p, _, _ in tracker.regressed()] == ["kr/민법/법률.md"]
+
+
+def test_same_date_and_number_lower_mst_is_a_regression(law_repo):
+    """공포번호까지 같으면 MST 가 마지막 tie-break 다."""
+    _commit_version(law_repo, "kr/민법/법률.md", "300", "2024-01-15", "00031")
+
+    tracker = VersionTracker()
+    tracker.seen("kr/민법/법률.md")
+    tracker.committed("kr/민법/법률.md", {"공포일자": "20240115", "공포번호": "00031"}, "299")
+
+    assert [p for p, _, _ in tracker.regressed()] == ["kr/민법/법률.md"]
+
+
+def test_same_date_higher_promulgation_number_is_not_a_regression(law_repo):
+    _commit_version(law_repo, "kr/민법/법률.md", "300", "2024-01-15", "00031")
+
+    tracker = VersionTracker()
+    tracker.seen("kr/민법/법률.md")
+    tracker.committed("kr/민법/법률.md", {"공포일자": "20240115", "공포번호": "00032"}, "301")
+
+    assert tracker.regressed() == []
+
+
+def test_promulgation_number_compares_numerically_not_lexically(law_repo):
+    """31 > 8 이지만 문자열로는 '31' < '8' 이다 — 문자 비교면 허위 퇴행이 뜬다."""
+    _commit_version(law_repo, "kr/민법/법률.md", "300", "2024-01-15", "8")
+
+    tracker = VersionTracker()
+    tracker.seen("kr/민법/법률.md")
+    tracker.committed("kr/민법/법률.md", {"공포일자": "20240115", "공포번호": "31"}, "301")
+
+    assert tracker.regressed() == []
+
+
+def test_zero_padded_promulgation_number_is_the_same_version(law_repo):
+    """'00031' 과 '31' 은 같은 개정이므로 퇴행이 아니다."""
+    _commit_version(law_repo, "kr/민법/법률.md", "300", "2024-01-15", "00031")
+
+    tracker = VersionTracker()
+    tracker.seen("kr/민법/법률.md")
+    tracker.committed("kr/민법/법률.md", {"공포일자": "20240115", "공포번호": "31"}, "300")
+
+    assert tracker.regressed() == []
+
+
+def test_newer_version_after_older_leaves_nothing_to_restore(law_repo):
+    """Ascending order within one run is the normal path — no restore needed."""
+    _commit_version(law_repo, "kr/민법/법률.md", "100", "1990-01-01", "00001")
+
+    tracker = VersionTracker()
+    tracker.seen("kr/민법/법률.md")
+    tracker.committed("kr/민법/법률.md", {"공포일자": "20240115", "공포번호": "00031"}, "300")
+
+    assert tracker.regressed() == []
+
+
+def test_file_absent_from_head_is_not_a_regression(law_repo):
+    """A brand-new law has no baseline to fall behind."""
+    _commit_version(law_repo, "kr/민법/법률.md", "300", "2024-01-15", "00031")
+
+    tracker = VersionTracker()
+    tracker.seen("kr/신법/법률.md")
+    tracker.committed("kr/신법/법률.md", {"공포일자": "20240101", "공포번호": "00001"}, "400")
+
+    assert tracker.regressed() == []
+
+
+def test_seen_is_idempotent_and_keeps_the_first_baseline(law_repo):
+    _commit_version(law_repo, "kr/민법/법률.md", "300", "2024-01-15", "00031")
+
+    tracker = VersionTracker()
+    tracker.seen("kr/민법/법률.md")
+    tracker.committed("kr/민법/법률.md", {"공포일자": "19900101", "공포번호": "00001"}, "100")
+    tracker.seen("kr/민법/법률.md")  # must not reset the baseline to the older commit
+
+    assert tracker.regressed() == [("kr/민법/법률.md", "300", "19900101")]
+
+
+def test_missing_promulgation_date_sorts_lowest(law_repo):
+    _commit_version(law_repo, "kr/민법/법률.md", "300", "2024-01-15", "00031")
+
+    tracker = VersionTracker()
+    tracker.seen("kr/민법/법률.md")
+    tracker.committed("kr/민법/법률.md", {"공포일자": "", "공포번호": ""}, "1")
+
+    assert [p for p, _, _ in tracker.regressed()] == ["kr/민법/법률.md"]

--- a/tests/test_laws/test_version_tracker.py
+++ b/tests/test_laws/test_version_tracker.py
@@ -12,6 +12,7 @@ import subprocess
 import pytest
 
 from laws import git_engine
+from laws import import_laws
 from laws.import_laws import VersionTracker
 
 
@@ -168,3 +169,34 @@ def test_missing_promulgation_date_sorts_lowest(law_repo):
     tracker.committed("kr/민법/법률.md", {"공포일자": "", "공포번호": ""}, "1")
 
     assert [p for p, _, _ in tracker.regressed()] == ["kr/민법/법률.md"]
+
+
+def test_csv_backfill_restores_head_snapshot_without_detail_fetch(law_repo, monkeypatch, tmp_path):
+    """CSV fallback must restore HEAD without assuming a detail XML or API key exists."""
+    _commit_version(law_repo, "kr/민법/법률.md", "300", "2024-01-15", "00031")
+    monkeypatch.setattr(import_laws, "KR_DIR", law_repo / "kr")
+    monkeypatch.setattr(import_laws, "get_processed_msts", lambda: set())
+    monkeypatch.setattr(import_laws, "mark_processed", lambda _mst: None)
+    monkeypatch.setattr(import_laws, "parse_csv", lambda _path: [{
+        "법령MST": "100",
+        "소관부처명": "법무부",
+        "법령ID": "000001",
+        "법령명": "민법",
+        "공포일자": "19900101",
+        "공포번호": "1",
+        "시행일자": "19900101",
+        "법령구분코드": "A",
+        "법령구분명": "법률",
+        "법령분야명": "민사",
+    }])
+    monkeypatch.setattr(
+        import_laws,
+        "get_law_detail",
+        lambda _mst: pytest.fail("CSV 복원은 상세 조회를 호출하면 안 된다"),
+    )
+
+    import_laws.import_from_csv(tmp_path / "fallback.csv")
+
+    assert "법령MST: 300" in subprocess.check_output(
+        ["git", "show", "HEAD:kr/민법/법률.md"], cwd=law_repo, text=True
+    )


### PR DESCRIPTION
## 현상

연혁 백필 후 일부 법령의 HEAD가 **구버전 본문을 현행으로 제공한다.** 실제 수집에서 6개 법령이 수개월 전 버전으로 퇴행했다.

```
kr/국가공무원법/법률.md 커밋 이력
  4056c9c7a1  (구버전 공포일자)  ← HEAD (백필이 커밋)
  c4bc221325  (신버전 공포일자)  ← 그 아래에 깔림
```

파일 이력에는 두 버전이 다 있지만 tip이 과거를 가리킨다. 저장소를 clone해 읽는 쪽은 폐지된 조문을 현행으로 받는다.

## 원인

`update`에는 `_restore_newer_current_laws`가 있으나 **import 계열 세 경로에는 대응물이 없다** — `import_from_cache`, `import_law_with_history`, `import_from_csv`. 이 경로들도 `commit_exists` 기반 dedup 스킵이 일어나므로 같은 방식으로 퇴행한다.

동작 순서는 이렇다.

1. 백필이 뒤늦게 발견한 과거 MST를 커밋 → 파일이 과거 본문으로 덮인다
2. 최신 MST는 이미 커밋돼 있어 dedup에 걸려 **재커밋되지 않는다**
3. 결과적으로 파일이 과거 상태로 남는다

## 수정

`VersionTracker`를 도입해 파일별로 **HEAD 기준 최신본**과 **현재 보유본**을 추적하고, 루프 종료 후 뒤처진 파일에 최신본을 재커밋한다. 과거 버전 커밋은 그대로 남으므로 연혁은 보존된다.

버전 비교는 `(공포일자, 공포번호, MST)` 순으로 `converter.entry_sort_key`의 정본 정렬과 같은 기준이다. 같은 날 공포된 다른 MST도 정확히 구분된다.

**`rebuild`는 제외했다** — orphan 브랜치에 정본 순서로 전량을 재생성하고 dedup 스킵이 없어 최신본이 항상 마지막에 커밋되므로 퇴행이 구조적으로 불가능하다. 나중에 잘못 "고치는" 일이 없도록 그 불변식을 docstring에 남겼다.

`head_law_version`은 frontmatter를 `_frontmatter_value`로 읽는다. `build_csv_markdown`은 `공포일자: 'YYYY-MM-DD'`처럼 인용 스칼라를 쓰고 API 경로는 비인용이라, 따옴표를 벗기지 않으면 작은따옴표(`0x27`)가 모든 숫자보다 작아 **기준선이 최하위로 밀리고 가드가 조용히 무력화된다.**

## 테스트

`tests/test_laws/test_version_tracker.py` 14건을 추가했다. 실제 git 저장소를 만들어 커밋한 뒤 판정한다.

| 구분 | 검증 |
|---|---|
| frontmatter | 인용/비인용 양쪽 파싱, HEAD에 없는 경로는 `None` |
| 핵심 | 구버전 백필 시 퇴행 감지 (인용/비인용 각각) |
| tie-break | 같은 날짜 공포번호 대소, 공포번호까지 같을 때 MST, 숫자 비교(31 > 8), zero-pad 동치 |
| 무퇴행 | 정순 커밋, HEAD 부재 신규 파일 |
| 기타 | `seen` 멱등성, 공포일자 결측 |

**뮤테이션으로 판별력을 확인했다.** 프로덕션 코드 복사본에 결함을 주입하면 각각 테스트가 죽는다.

```
_order 에서 공포번호 제거   → 1 failed
_order 에서 MST 제거        → 1 failed
_order 를 문자열 비교로     → 1 failed
_frontmatter_value 를 옛 정규식으로 → 2 failed
```

**감도 대조**도 했다. 인용 frontmatter로 34년치 퇴행을 만들면 수정 전에는 감지되지 않는다.

```
[수정 후] head_law_version → ('20240115', '20000', '999999')   regressed() → 감지
[수정 전] head_law_version → ("'20240115'", '20000', '999999')  regressed() → []
```

실전 검증으로 수년 전 MST 4건을 임포트한 결과다.

```
Cache import done: committed=4, restored=2, errors=0
  HEAD regressed for kr/국토의계획및이용에관한법률/시행령.md (holds 20210706) — restoring MST=287269
  HEAD regressed for kr/법원공무원규칙/대법원규칙.md (holds 20180831) — restoring MST=288027
```

## 결과

HEAD가 최신본으로 복원되고 과거 버전도 이력에 남는다.

```
kr/법원공무원규칙/대법원규칙.md              HEAD = MST 288027 (최신본)
kr/국토의계획및이용에관한법률/시행령.md        HEAD = MST 287269 (최신본)
과거 4건 커밋 잔존: 9a1bf6a9eb, 666418790b, 2c074b2a1a, 372cce298f
```

전체 스위트 687 passed, 0 failed.
