### PR TITLE
fix(laws): 항 직속으로 오는 목

### DIFF
--- a/laws/api_client.py
+++ b/laws/api_client.py
@@ -152,6 +152,14 @@ def search_laws(
     return {"totalCnt": int(total), "page": int(page_num), "laws": laws}
 
 
+def _item_from_xml(mok: ElementTree.Element) -> dict:
+    return {
+        "목번호": mok.findtext("목번호", ""),
+        "목가지번호": mok.findtext("목가지번호", ""),
+        "목내용": mok.findtext("목내용", ""),
+    }
+
+
 def get_law_detail(
     mst_id: str | int,
     *,
@@ -216,24 +224,24 @@ def get_law_detail(
                 "항가지번호": hang.findtext("항가지번호", ""),
                 "항내용": hang.findtext("항내용", ""),
             }
-            # Parse 호 (subparagraphs)
+            # Parse 호 (subparagraphs) and 목 (items).
+            # 목 arrives in one of two shapes depending on when the payload was
+            # fetched: nested under its 호 (older responses), or as a sibling of
+            # 호 directly under 항 (current responses). In the sibling shape the
+            # owning 호 is the one preceding it in document order.
             subparas = []
-            for ho in hang.findall(".//호"):
-                subpara = {
-                    "호번호": ho.findtext("호번호", ""),
-                    "호가지번호": ho.findtext("호가지번호", ""),
-                    "호내용": ho.findtext("호내용", ""),
-                }
-                # Parse 목 (items)
-                items = []
-                for mok in ho.findall(".//목"):
-                    items.append({
-                        "목번호": mok.findtext("목번호", ""),
-                        "목가지번호": mok.findtext("목가지번호", ""),
-                        "목내용": mok.findtext("목내용", ""),
-                    })
-                subpara["목"] = items
-                subparas.append(subpara)
+            current = None
+            for child in hang:
+                if child.tag == "호":
+                    current = {
+                        "호번호": child.findtext("호번호", ""),
+                        "호가지번호": child.findtext("호가지번호", ""),
+                        "호내용": child.findtext("호내용", ""),
+                        "목": [_item_from_xml(mok) for mok in child.findall(".//목")],
+                    }
+                    subparas.append(current)
+                elif child.tag == "목" and current is not None:
+                    current["목"].append(_item_from_xml(child))
             para["호"] = subparas
             paragraphs.append(para)
         article["항"] = paragraphs

--- a/tests/test_laws/test_api_client.py
+++ b/tests/test_laws/test_api_client.py
@@ -337,3 +337,47 @@ def test_get_law_history_from_cache(tmp_path: Path):
     history = api_client.get_law_history("민법")
     assert history == entries
     assert len(responses_lib.calls) == 0
+
+
+def _items_xml(nested: bool) -> bytes:
+    items = (
+        "<목><목번호><![CDATA[가.]]></목번호><목내용><![CDATA[가. 첫째 요건]]></목내용></목>"
+        "<목><목번호><![CDATA[나.]]></목번호><목내용><![CDATA[나. 둘째 요건]]></목내용></목>"
+    )
+    ho2 = "<호><호번호><![CDATA[2.]]></호번호><호내용><![CDATA[2. 다음 각 목의 요건을 갖춘 경우]]></호내용>"
+    ho2 += items + "</호>" if nested else "</호>" + items
+    return f"""<?xml version="1.0" encoding="UTF-8"?>
+<법령>
+  <기본정보>
+    <법령명_한글><![CDATA[테스트법]]></법령명_한글>
+    <법종구분>법률</법종구분>
+  </기본정보>
+  <조문>
+    <조문단위>
+      <조문번호>3</조문번호>
+      <조문여부>조문</조문여부>
+      <조문제목><![CDATA[적용 대상]]></조문제목>
+      <조문내용><![CDATA[제3조(적용 대상) 본문]]></조문내용>
+      <항>
+        <항번호><![CDATA[③]]></항번호>
+        <항내용><![CDATA[③ 다음 각 호의 어느 하나에 해당하는 경우를 말한다.]]></항내용>
+        <호><호번호><![CDATA[1.]]></호번호><호내용><![CDATA[1. 첫째 경우]]></호내용></호>
+        {ho2}
+      </항>
+    </조문단위>
+  </조문>
+</법령>""".encode()
+
+
+@pytest.mark.parametrize("nested", [False, True], ids=["sibling", "nested"])
+@responses_lib.activate
+def test_get_law_detail_attaches_items_to_owning_subparagraph(nested: bool):
+    """목 arrives nested under its 호 or as a sibling of 호 under 항."""
+    responses_lib.add(
+        responses_lib.GET, f"{LAW_API_BASE}/lawService.do", body=_items_xml(nested), status=200
+    )
+    detail = api_client.get_law_detail("37612")
+    subparas = detail["articles"][0]["항"][0]["호"]
+    assert [len(h["목"]) for h in subparas] == [0, 2]
+    assert subparas[1]["목"][0]["목번호"] == "가."
+    assert subparas[1]["목"][1]["목내용"] == "나. 둘째 요건"


### PR DESCRIPTION
법령 상세 응답에서 **목(items)이 한 건도 파싱되지 않습니다.** 응답 구조가 바뀐 것이 원인입니다.

## 증상

`laws/api_client.py`는 목을 소속 호 아래에서 찾습니다.

```python
for ho in hang.findall(".//호"):
    for mok in ho.findall(".//목"):   # 현행 응답에서는 항상 빈 결과
```

예전 응답은 `호 > 목`으로 중첩해서 왔는데, 현재는 목이 호와 나란히 `항 > 목`으로 옵니다. 그래서 위 코드가 목을 하나도 못 읽습니다.

## legalize-kr 데이터에 이미 반영되고 있습니다

커밋별로 목 줄(`    가\.` 형태) 증감을 세어봤습니다.

```
7/27   목+ 8  목- 2   (개정에 따른 정상 증감)
7/28   목+17  목-10
7/29   목+ 2  목- 1
────────────────────────────────────────  경계
7/30   목+ 0  목-73   개별소비세법 시행령
7/30   목+ 0  목-41   공동주택관리법 시행규칙
7/30   목+ 0  목-41   석유 및 석유대체연료 사업법 시행령
7/30   목+ 0  목-29   교통ㆍ에너지ㆍ환경세법 시행령
7/30   목+ 0  목-19   국가재정법 시행령
7/31   목+ 0  목-97   관세법 시행규칙
7/31   목+ 0  목-42   경찰청과 그 소속기관 직제 시행규칙
                      (7/30~31 총 16건)
```

7/29까지는 개정에 따라 목이 늘고 주는데, **7/30부터는 추가가 0이고 삭제만** 나옵니다. 세법·보훈·경찰 직제·공무원 보수 등 분야를 가리지 않습니다.

현재 API 응답과 대조하면 실제로 비어 있습니다.

| 법령 | API 응답의 목 | `kr/**.md` |
|---|---|---|
| 관세법 시행규칙 (MST 288525) | 97 | 0 |
| 국가재정법 시행령 (MST 288443) | 19 | 0 |

## 법령 버전이 아니라 응답 형식이 바뀐 것입니다

2026-05-25에 `호>목`으로 캐시해둔 MST를 지금 다시 받으면 같은 MST·같은 공포일자인데 `항>목`으로 옵니다.

```
$ curl "https://www.law.go.kr/DRF/lawService.do?OC=...&target=law&MST=<MST>&type=XML"
  → 항>목 224 · 호>목 0     (5/25 캐시본은 호>목 224 · 항>목 0)
```

로컬 캐시로 파싱만 대조한 결과입니다.

```
수정 전   현행 응답 목   0개  · 구형 응답 목 224개
수정 후   현행 응답 목 224개  · 구형 응답 목 224개
```

`AGENTS.md`의 마크다운 변환 규칙에도 목이 `    가\. 내용` 으로 명시돼 있어 의도된 동작은 아니라고 판단했습니다.

## 수정

항의 자식을 **문서 순서대로** 훑어, 호를 만나면 현재 호를 갱신하고 목은 직전 호에 붙입니다. 호 안에 중첩된 목도 계속 읽으므로 **기존 캐시와 호환**됩니다.

- 선행 호 없이 나오는 목은 캐시 전수에서 0건이라 별도 처리하지 않았습니다 (`laws/converter.py`도 `subpara["목"]`만 소비합니다).
- XML의 목을 파싱하는 곳은 이 한 군데뿐인 것으로 확인했습니다.
- 테스트는 두 배치를 모두 검증하도록 파라미터화했습니다. 픽스처는 목이 두 번째 호에만 달린 구조라 '직전 호'에 붙는지까지 확인됩니다.
- `tests` 657개 통과 (`hypothesis` 미설치로 `test_precedents/test_converter_composite.py`만 제외).

## 질문

`f5e8531` 커밋 메시지에 "Rust 대응 구현: legalize-kr/compiler"가 있던데, `compiler` 쪽에도 같은 파싱이 있다면 함께 고쳐야 할 것 같습니다.

재수집하면 복구되는 값이라 영구 손실은 아니지만, 매일 갱신분마다 계속 쌓입니다.
